### PR TITLE
Add functions to display error details for configured domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -68,6 +68,7 @@
       showPopup: false,
       showPopupOnMouseOver: false,
       showTrace: false,
+      showDetailOnIncludeDomains: false,
     }
     for (var option in optionsValues) {
       var value = optionsValues[option]
@@ -169,7 +170,8 @@
       popupMaxHeight: await LS.getItem('popupMaxHeight'),
       includeDomains: await LS.getItem('includeDomains'),
       iconSize: await LS.getItem('iconSize'),
-      notificationIconOpacity: await LS.getItem('notificationIconOpacity')
+      notificationIconOpacity: await LS.getItem('notificationIconOpacity'),
+      showDetailOnIncludeDomains: await LS.getItem('showDetailOnIncludeDomains'),
     }
   }
 

--- a/content.js
+++ b/content.js
@@ -35,7 +35,7 @@ new (function () {
   }
 
   function showErrorNotification(popupUrl) {
-    if (options.showPopup) {
+    if (options.showPopup || (options.showDetailOnIncludeDomains && options.includeDomains.indexOf(getBaseHostByUrl(window.location.href)) + 1)) {
       showPopup(popupUrl)
     }
     var includeSite = false
@@ -192,5 +192,14 @@ new (function () {
       })
       options = response
     })()
+  }
+
+  function getBaseHostByUrl(url) {
+    var localUrlRegexp = /(file:\/\/.*)|(:\/\/[^.:]+([\/?:]|$))/ // file:// | local
+    var rootHostRegexp = /:\/\/(([\w-]+\.\w+)|(\d+\.\d+\.\d+\.\d+)|(\[[\w:]+\]))([\/?:]|$)/ // domain.com | IPv4 | IPv6
+    var subDomainRegexp = /:\/\/[^\/]*\.([\w-]+\.\w+)([\/?:]|$)/ // sub.domain.com
+    return localUrlRegexp.exec(url)
+      ? 'localhost'
+      : (rootHostRegexp.exec(url) || subDomainRegexp.exec(url))[1]
   }
 })()

--- a/options.html
+++ b/options.html
@@ -109,6 +109,13 @@
         <label>Include domains - disable 'icon on all domains' to use only these domains<br>
           <textarea id="includeDomains" rows="3" style="width: 80%; max-width: 80%;"></textarea>
         </label>
+        <label>
+          <input
+              type="checkbox"
+              id="showDetailOnIncludeDomains"
+          />
+          % - show error details on these domains
+        </label>
       </p>
       <p>
         <label>

--- a/options.html
+++ b/options.html
@@ -114,7 +114,7 @@
               type="checkbox"
               id="showDetailOnIncludeDomains"
           />
-          % - show error details on these domains
+          show error details on these domains
         </label>
       </p>
       <p>

--- a/options.js
+++ b/options.js
@@ -41,6 +41,7 @@ function filloutOptions() {
     'showPopup',
     'showPopupOnMouseOver',
     'showTrace',
+    'showDetailOnIncludeDomains',
   ]
 
   if (options['notificationIconOpacity'] == undefined) {


### PR DESCRIPTION
## Description:
This feature provides users with the option to view error details for configured domains via pop-ups

## Changes Made:
- Implemented functions to display error details on user-configured domains.

## How to Test:
- Navigate to the settings section.
- Configure a domain for monitoring.
- Enable the `show error details on these domains` option.
- Trigger an error on the configured domain.
- Observe the pop-up displaying error details.
- Ensure the error details are accurate and informative.
- Verify that the pop-up functionality works as expected for different types of errors.
